### PR TITLE
Add link to Jira tickets in theme names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ A very opinionated extension that does some (hopefully) useful things on Shopify
 
 ### Features
 
-#### Quick-Copy Theme IDs
-On the themes page in the admin panel, the theme's ID will be printed in the theme's row. Clicking on the ID will copy it to your clipboard.
-
-#### Quick-Copy Preview URL
-In the same vein, click the 'Copy preview URL' under a theme to copy the theme's preview URL to your clipboard.
+#### Admin Panel Theme Page Additions
+* On the themes page in the admin panel, the theme's ID will be printed in the theme's row.  
+  Clicking on the ID will copy it to your clipboard.
+* A 'Copy preview URL' link is added under a theme to copy the theme's preview URL to your clipboard.
+* If the theme name contains a Jira ticket code, it will it convert into a link that opens in a new tab.
 
 #### Compact Admin Bar
 On the frontend of any Shopify site, the standard admin bar which shows you which theme you're currently previewing is made much more compact. Only the theme's name and a close button remains.

--- a/src/admin-themes/jira-ticket.js
+++ b/src/admin-themes/jira-ticket.js
@@ -1,0 +1,54 @@
+class JiraTicketLinker {
+  constructor() {
+    this.init();
+  }
+
+  init() {
+    this.getThemeList().forEach((item, i) => {
+      // The live theme won't/shouldn't have a Jira code
+      // and won't be matched by the following selector
+      const themeName = item.querySelector('h3 > div > div > span');
+      if (themeName === null) {
+        return;
+      }
+
+      // Find a Jira code using regex
+      // @see https://community.atlassian.com/t5/Bitbucket-questions/Regex-pattern-to-match-JIRA-issue-key/qaq-p/233319
+      const jiraCodeMatches = themeName.innerText.match(/((?<!([A-Z]{1,10})-?)[A-Z]+-\d+)/);
+
+      // If there is no Jira code, move on
+      if (! jiraCodeMatches) {
+        return;
+      }
+
+      const jiraCode = jiraCodeMatches[0];
+
+      // Replace the Jira code with an external link to the ticket
+      // @todo Allow for the Jira account name to be configured?
+      const account = "teamstrawberry";
+      const jiraTicketUrl = `<a href="https://${account}.atlassian.net/browse/${jiraCode}" target="_blank" class="jira-ticket-url">${jiraCode}</a>`;
+
+      themeName.innerHTML = themeName.innerHTML.replace(jiraCode, jiraTicketUrl);
+    })
+  }
+
+  /**
+   * Gets an array of all the theme row elements.
+   * Helpful method by Kieran. Would be nice to get this as a utility method somewhere.
+   *
+   * @returns {Element[]}
+   */
+  getThemeList() {
+    const live = document.querySelectorAll('[testid="PublishedThemeSectionWrapper"]');
+    const library = [...document.querySelectorAll('li a[href$="/editor"]')].map(customize => {
+      let el = customize;
+      while (el.tagName !== 'LI') {
+        el = el.parentNode;
+      }
+      return el;
+    });
+    return [...live].concat(library);
+  }
+}
+
+setTimeout(() => new JiraTicketLinker, 500);

--- a/src/admin-themes/style.css
+++ b/src/admin-themes/style.css
@@ -13,3 +13,7 @@
   font-size: 12px;
   text-decoration: none;
 }
+
+.jira-ticket-url {
+  color: #084e8a;
+}

--- a/src/admin-themes/style.css
+++ b/src/admin-themes/style.css
@@ -16,4 +16,5 @@
 
 .jira-ticket-url {
   color: #084e8a;
+  text-decoration: none;
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -8,7 +8,7 @@
         {
         "matches": ["https://*.myshopify.com/admin/online-store/themes*"],
           "css": ["admin-themes/style.css"],
-          "js": ["admin-themes/script.js"],
+          "js": ["admin-themes/script.js", "admin-themes/jira-ticket.js"],
           "all_frames": true,
           "run_at": "document_idle"
         },


### PR DESCRIPTION
Finds Jira ticket codes and adds a link to them to open in Jira.

For now, it's fixed to use Strawberry's account, but it would be nice to have this configurable.

![image](https://user-images.githubusercontent.com/915909/84145400-b55c0100-aa51-11ea-8765-7a6beea7cc25.png)
