### PR TITLE
Add suggestions when renaming a theme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,22 @@ A very opinionated extension that does some (hopefully) useful things on Shopify
   Clicking on the ID will copy it to your clipboard.
 * A 'Copy preview URL' link is added under a theme to copy the theme's preview URL to your clipboard.
 * If the theme name contains a Jira ticket code, it will it convert into a link that opens in a new tab.
+* When renaming a theme, you can choose from some preset suggestions.
 
 #### Compact Admin Bar
 On the frontend of any Shopify site, the standard admin bar which shows you which theme you're currently previewing is made much more compact. Only the theme's name and a close button remains.
 
 ##### Caveats
+**Theme name identifiers**
+
 The theme ID and preview URL functionality only works with themes that have an emoji prefix. This shouldn't be an issue since they should have one, anyway. Any of the following are acceptable:
 
 💾✨🐞🛠🌍🌎🌏
 
 It would be nice if this weren't a requirement, but it was the easiest way to determine what element is a theme to filter them down. I don't want to rely on class names or similar DOM selectors as they are obfuscated and subject to change.
+
+**Theme rename suggestions**
+
+Unfortunately, I can't find a way to trick the Polaris text field into thinking it's been updated once the suggestion has been inserted, meaning the 'Rename' button is left disabled. Also, on blur, the previous name will re-populate the field. Whenever you click a suggestion, you must then type a space or anything else into the box, which will counteract both of these issues.
+
+A message will appear reminding the user to type something in order to continue.

--- a/src/admin-themes/background.js
+++ b/src/admin-themes/background.js
@@ -1,0 +1,22 @@
+/**
+ * This listens for the "rename_iframe_loaded" event which is dispatched in rename-suggestions-observer.js,
+ * then in turn injects the theme suggestions script into the tab and its frames.
+ *
+ * This will inject the code into ALL frames, and the script will then determine if it's been loaded
+ * into the correct one before executing.
+ *
+ * @todo Only inject the scripts into the correct frame
+ */
+chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  if (request.type === "rename_iframe_loaded") {
+    chrome.tabs.executeScript(sender.tab.id, {
+      code: "themeRenameSuggestions.init()",
+      allFrames: true,
+    });
+
+    chrome.tabs.insertCSS(sender.tab.id, {
+      file: "admin-themes/style.css",
+      allFrames: true,
+    })
+  }
+});

--- a/src/admin-themes/rename-suggestions-observer.js
+++ b/src/admin-themes/rename-suggestions-observer.js
@@ -1,0 +1,30 @@
+/**
+ * The iframe to rename a theme doesn't exist when the page first loads, so we need to listen
+ * for whenever a new iframe is loaded. We'll listen for any mutations and filter out
+ * any mutations that aren't the correct iframe.
+ *
+ * @type {MutationObserver}
+ */
+const observer = new MutationObserver((mutationsList, observer) => {
+  // Check to see if we've opened an iframe
+  const iframe = mutationsList.find(record => record.target.tagName === "IFRAME");
+
+  if (! iframe) {
+    return;
+  }
+
+  const element = iframe.target;
+  const label = element.contentWindow.document.querySelector('label');
+
+  // Check to see if the iframe we've loaded is to rename the theme
+  if (! label || label.innerText !== "Provide a new name for this theme") {
+    return;
+  }
+
+  // Send a message that we've loaded the rename iframe
+  chrome.runtime.sendMessage({
+    type: "rename_iframe_loaded"
+  })
+});
+
+observer.observe(document, { attributes: true, childList: true, subtree: true });

--- a/src/admin-themes/rename-suggestions.js
+++ b/src/admin-themes/rename-suggestions.js
@@ -1,0 +1,131 @@
+class ThemeRenameSuggestions {
+  /**
+   * The list of suggestions to show.
+   *
+   * @todo Make this list configurable
+   *
+   * @returns {string[]}
+   */
+  get suggestions() {
+    const currentDate = new Date().toJSON().slice(0, 10);
+
+    return [
+      `💾 ${currentDate}`,
+      "🛠",
+      "✨",
+      "🐞",
+      "🌍"
+    ]
+  }
+
+  /**
+   * The Polaris input field
+   *
+   * @returns {HTMLInputElement}
+   */
+  get inputBox() {
+    return document.querySelector('input');
+  }
+
+  /**
+   * The outer-outer parent of the input box
+   *
+   * @returns {HTMLElement}
+   */
+  get inputBoxContainer() {
+    return this.inputBox.parentElement.parentElement;
+  }
+
+  /**
+   * Once added to the page, this will provide an accessor to the suggestion buttons
+   *
+   * @returns {NodeListOf<Element>}
+   */
+  get suggestionButtons() {
+    return document.querySelectorAll('[data-theme-name-suggestion]')
+  }
+
+  init() {
+    if (!this.isRenameModal()) {
+      return;
+    }
+
+    this.addSuggestions();
+    this.addEventListeners();
+  }
+
+  /**
+   * Add the suggestions buttons to the modal
+   */
+  addSuggestions() {
+    const suggestionsContainer = document.createElement('div');
+
+    suggestionsContainer.classList.add('suggestions-container');
+    suggestionsContainer.innerHTML = this.suggestions.map(suggestion => {
+      return `<button role="button" data-theme-name-suggestion="${suggestion}">${suggestion}</button>`;
+    }).join('');
+
+    this.inputBoxContainer.appendChild(suggestionsContainer);
+  }
+
+  /**
+   * Add event listeners for clicking the suggestions buttons and typing in the field
+   */
+  addEventListeners() {
+    // Add the suggestion into the input field
+    this.suggestionButtons.forEach(item => {
+      item.addEventListener('click', () => {
+        this.inputBox.focus();
+        this.inputBox.setAttribute('value', item.dataset.themeNameSuggestion);
+        this.inputBox.value = item.dataset.themeNameSuggestion;
+        this.showTypingReminder();
+      });
+    });
+
+    // Hide the typing reminder since the user has already typed
+    this.inputBox.addEventListener('input', this.hideTypingReminder);
+  }
+
+  /**
+   * Remind the user that they must type something in order to let the input
+   * field know there has been an update to its content
+   */
+  showTypingReminder() {
+    const existingTypingReminder = document.getElementById('typing-reminder');
+    if (existingTypingReminder) {
+      return;
+    }
+
+    const reminder = document.createElement('div');
+    reminder.id = 'typing-reminder';
+    reminder.innerText = 'Hit space or continue typing.';
+    this.inputBoxContainer.appendChild(reminder);
+  }
+
+  /**
+   * Hide the typing reminder once the user has typed something and
+   * the input field has been updated properly
+   */
+  hideTypingReminder() {
+    const typingReminder = document.getElementById('typing-reminder');
+    if (typingReminder) {
+      typingReminder.remove();
+    }
+  }
+
+  /**
+   * Determine if the current modal that the script has been injected
+   * into is in fact a theme rename modal
+   *
+   * @returns {boolean}
+   */
+  isRenameModal() {
+    const renameLabel = Array.from(
+      document.querySelectorAll('label')
+    ).find(item => item.innerText === 'Provide a new name for this theme');
+
+    return typeof renameLabel !== 'undefined';
+  }
+}
+
+const themeRenameSuggestions = new ThemeRenameSuggestions;

--- a/src/admin-themes/style.css
+++ b/src/admin-themes/style.css
@@ -18,3 +18,18 @@
   color: #084e8a;
   text-decoration: none;
 }
+
+.suggestions-container {
+  display: flex;
+  margin: 1rem 0;
+}
+
+.suggestions-container button[data-theme-name-suggestion] {
+  background: linear-gradient(180deg,#fff,#f9fafb);
+  border: .1rem solid var(--p-border,#c4cdd5);
+  box-shadow: 0 1px 0 0 rgba(22,29,37,.05);
+  border-radius: 3px;
+  cursor: pointer;
+  height: 26px;
+  margin: 0 0.5rem 0 0;
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,12 +3,32 @@
     "description" : "A very opinionated extension that does some (hopefully) useful things on Shopify stores.",
     "version": "1.0",
     "manifest_version": 2,
+    "permissions": [
+      "activeTab",
+      "tabs",
+      "https://*.myshopify.com/*"
+    ],
+    "background": {
+      "scripts": [
+        "admin-themes/background.js"
+      ],
+      "persistent": false
+    },
     "content_scripts":
       [
         {
         "matches": ["https://*.myshopify.com/admin/online-store/themes*"],
           "css": ["admin-themes/style.css"],
           "js": ["admin-themes/script.js", "admin-themes/jira-ticket.js"],
+          "all_frames": true,
+          "run_at": "document_idle"
+        },
+        {
+          "matches": ["https://*.myshopify.com/admin/*"],
+          "js": [
+            "admin-themes/rename-suggestions.js",
+            "admin-themes/rename-suggestions-observer.js"
+          ],
           "all_frames": true,
           "run_at": "document_idle"
         },


### PR DESCRIPTION
In the theme rename modal, a bunch of common name suggestions will be available to auto-fill the name.

At the moment, there's:

* A backup theme name with the current date
* Emoji prefixes for developer/feature/bugfix/live themes

In the future, I would like to have this list configurable (for example, you would want the "🛠" suggestion to be "🛠 Your Name". Also, not everybody will use the same conventions we do, so it will be good for other users using it.

There is a slight caveat that still requires you to type something – I've covered that in the readme.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/915909/84178904-16e59500-aa7d-11ea-9632-cb7837e79abe.gif)

